### PR TITLE
use the new whileBusy mechanism to lock all public access to a locale…

### DIFF
--- a/lib/modules/apostrophe-review-and-deploy-global/index.js
+++ b/lib/modules/apostrophe-review-and-deploy-global/index.js
@@ -1,0 +1,15 @@
+module.exports = {
+  improve: 'apostrophe-global',
+  construct: function(self, options) {
+    // Exempt our own API routes from the whileBusy lock
+    const superCheckWhileBusy = self.checkWhileBusy;
+    self.checkWhileBusy = function(req, _global, callback) {
+      var review = self.apos.modules['apostrophe-review-and-deploy'];
+      var route = review.action + '/job/progress';
+      if (req.url.substr(0, route.length + 1) === route + '/') {
+        return callback(null);
+      }
+      return superCheckWhileBusy(req, _global, callback);
+    };
+  }
+};


### PR DESCRIPTION
… during the critical last phase when a deployment of a locale is being made live, avoiding any period in which users might see a mix of old and new content